### PR TITLE
Enabling CORS for serving the /skin on subdomain

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -227,6 +227,12 @@ SetEnvIf X-Forwarded-Proto https HTTPS=on
     AddCharset utf-8 .atom .css .js .json .rss .vtt .webapp .xml
 </IfModule>
 
+##### Enabling CORS on subdomain
+<FilesMatch "\.(ttf|ttc|otf|eot|woff|font.css)$">
+  <IfModule mod_headers.c>
+    Header set Access-Control-Allow-Origin "*" 
+  </IfModule>
+</FilesMatch>
 
 ##### Disable ETags http://developer.yahoo.com/performance/rules.html#etags #####
 


### PR DESCRIPTION
using a subdomain for serving the /skin directory that might be having problems with the icon fonts showing in the browser.
`
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://static.*removed*.com/skin/frontend/ultimo/default/fonts/themeicons/ThemeIcons.woff?387osh. This can be fixed by moving the resource to the same domain or enabling CORS.
`
